### PR TITLE
Update README.md with correct EF Core method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,10 @@ public class UlidToBytesConverter : ValueConverter<Ulid, byte[]>
 
 #### 2. Register the Converter in OnModelCreating
 
-Once the converter is created, you need to register it in your `DbContext`'s `OnModelCreating` method to apply it to `Ulid` properties:
+Once the converter is created, you need to register it in your `DbContext`'s `ConfigureConventions` virtual method to apply it to `Ulid` properties:
 
 ```csharp
-protected override void OnModelCreating(ModelBuilder modelBuilder)
+protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
 {
 	// ...
 	configurationBuilder

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ public class UlidToBytesConverter : ValueConverter<Ulid, byte[]>
 }
 ```
 
-#### 2. Register the Converter in OnModelCreating
+#### 2. Register the Converter in ConfigureConventions
 
 Once the converter is created, you need to register it in your `DbContext`'s `ConfigureConventions` virtual method to apply it to `Ulid` properties:
 


### PR DESCRIPTION
## Description
This is a minor docs update of the correct method name to use when applying an EF Core value conversion.