### PR TITLE
Add Ulid.Empty field and corresponding tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Gets the timestamp component of the ULID as a `DateTimeOffset`.
 Gets the time component of the ULID as a `ReadOnlySpan<byte>`.
 - `.Random`\
 Gets the random component of the ULID as a `ReadOnlySpan<byte>`.
+- `Ulid.Empty`\
+Represents an empty ULID, equivalent to `default(Ulid)` and `Ulid.New(new byte[16])`.
 
 ### Conversion Methods
 

--- a/src/ByteAether.Ulid.Tests/Ulid.Tests.cs
+++ b/src/ByteAether.Ulid.Tests/Ulid.Tests.cs
@@ -3,6 +3,17 @@
 namespace ByteAether.Ulid.Tests;
 public class UlidTests
 {
+	[Fact]
+	public void EmptyUlid_ShouldBeDefault()
+	{
+		// Arrange
+		var ulid = Ulid.Empty;
+
+		// Assert
+		Assert.Equal(default, ulid);
+		Assert.Equal(new byte[16], ulid.ToByteArray());
+	}
+
 	private static readonly byte[] _sampleUlidBytes =
 		[
             // Timestamp (6 bytes)

--- a/src/ByteAether.Ulid/Ulid.cs
+++ b/src/ByteAether.Ulid/Ulid.cs
@@ -26,6 +26,15 @@ public readonly partial struct Ulid
 	private const byte _ulidSizeRandom = 10;
 	private const byte _ulidSize = _ulidSizeTime + _ulidSizeRandom;
 
+	/// <summary>
+	/// Represents an empty ULID value.
+	/// </summary>
+	/// <remarks>
+	/// The <see cref="Empty"/> field is a ULID with all components set to zero.
+	/// It can be used as a default or placeholder value.
+	/// </remarks>
+	public static readonly Ulid Empty = default;
+
 	[FieldOffset(00)] private readonly byte _t0;
 	[FieldOffset(01)] private readonly byte _t1;
 	[FieldOffset(02)] private readonly byte _t2;


### PR DESCRIPTION
Introduce a static readonly field `Ulid.Empty` in the `Ulid` struct to represent an empty ULID value. This field serves as a default or placeholder. A new test method `EmptyUlid_ShouldBeDefault` is added to ensure `Ulid.Empty` behaves as expected, confirming it equals the default ULID and has a byte array of all zeros. Documentation comments are included to clarify the purpose of the `Ulid.Empty` field.

Implement solution described in #6.
