### PR TITLE
Monotonic increment can be 1-4 bytes of random value in addition to just +1 increment.

### DIFF
--- a/src/ByteAether.Ulid.Benchmarks/Program.cs
+++ b/src/ByteAether.Ulid.Benchmarks/Program.cs
@@ -41,7 +41,7 @@ public class Generate
 public class GenerateNonMono
 {
 	[Benchmark]
-	public ByteAether.Ulid.Ulid ByteAetherUlid() => ByteAether.Ulid.Ulid.New(isMonotonic: false);
+	public ByteAether.Ulid.Ulid ByteAetherUlid() => ByteAether.Ulid.Ulid.New(ByteAether.Ulid.Ulid.Monotonicity.NonMonotonic);
 
 	[Benchmark]
 	public System.Ulid Ulid() => System.Ulid.NewUlid();

--- a/src/ByteAether.Ulid.Benchmarks/Program.cs
+++ b/src/ByteAether.Ulid.Benchmarks/Program.cs
@@ -31,6 +31,12 @@ public class Generate
 	public ByteAether.Ulid.Ulid ByteAetherUlid() => ByteAether.Ulid.Ulid.New();
 
 	[Benchmark]
+	public ByteAether.Ulid.Ulid ByteAetherUlid1BR() => ByteAether.Ulid.Ulid.New(ByteAether.Ulid.Ulid.Monotonicity.MonotonicRandom1Byte);
+
+	[Benchmark]
+	public ByteAether.Ulid.Ulid ByteAetherUlid4BR() => ByteAether.Ulid.Ulid.New(ByteAether.Ulid.Ulid.Monotonicity.MonotonicRandom4Byte);
+
+	[Benchmark]
 	public NetUlid.Ulid NetUlid() => global::NetUlid.Ulid.Generate();
 
 	[Benchmark]

--- a/src/ByteAether.Ulid.Tests.AotConsole/Program.cs
+++ b/src/ByteAether.Ulid.Tests.AotConsole/Program.cs
@@ -9,148 +9,161 @@ Console.WriteLine("--------------------------------------------------");
 Console.WriteLine("\n--- ULID Creation ---");
 
 // 1.1 Create a new ULID (default monotonic)
-var ulid1 = Ulid.New();
-Console.WriteLine($"1.1 New ULID (default monotonic): {ulid1}");
+var ulid1_1 = Ulid.New();
+Console.WriteLine($"1.1 New ULID (default monotonic): {ulid1_1}");
 
 // 1.2 Create a new non-monotonic ULID
-var ulid2 = Ulid.New(isMonotonic: false);
-Console.WriteLine($"1.2 New ULID (non-monotonic):     {ulid2}");
+var ulid1_2 = Ulid.New(Ulid.Monotonicity.NonMonotonic);
+Console.WriteLine($"1.2 New ULID (non-monotonic):     {ulid1_2}");
 
-// 1.3 Create a new ULID from DateTimeOffset
+// 1.3 Create a new ULID with MonotonicRandom1Byte
+var ulid1_3 = Ulid.New(Ulid.Monotonicity.MonotonicRandom1Byte);
+Console.WriteLine($"1.3 New ULID (1-byte monotonic):  {ulid1_3}");
+
+// 1.4 Create a new ULID with MonotonicRandom2Byte
+var ulid1_4 = Ulid.New(Ulid.Monotonicity.MonotonicRandom2Byte);
+Console.WriteLine($"1.4 New ULID (2-byte monotonic):  {ulid1_4}");
+
+// 1.5 Create a new ULID with MonotonicRandom3Byte
+var ulid1_5 = Ulid.New(Ulid.Monotonicity.MonotonicRandom3Byte);
+Console.WriteLine($"1.5 New ULID (3-byte monotonic):  {ulid1_5}");
+
+// 1.6 Create a new ULID with MonotonicRandom4Byte
+var ulid1_6 = Ulid.New(Ulid.Monotonicity.MonotonicRandom4Byte);
+Console.WriteLine($"1.6 New ULID (4-byte monotonic):  {ulid1_6}");
+
+// 1.7 Create a new ULID from DateTimeOffset
 var specificTime = new DateTimeOffset(2023, 10, 26, 10, 30, 0, TimeSpan.Zero);
-var ulid3 = Ulid.New(specificTime);
-Console.WriteLine($"1.3 New ULID from DateTimeOffset: {ulid3} (Time: {ulid3.Time})");
+var ulid1_7 = Ulid.New(specificTime);
+Console.WriteLine($"1.7 New ULID from DateTimeOffset: {ulid1_7} (Time: {ulid1_7.Time})");
 
-// 1.4 Create a new ULID from Unix timestamp (long)
+// 1.8 Create a new ULID from Unix timestamp (long)
 var unixTimestamp = specificTime.ToUnixTimeMilliseconds();
-var ulid4 = Ulid.New(unixTimestamp);
-Console.WriteLine($"1.4 New ULID from Unix Timestamp: {ulid4} (Time: {ulid4.Time})");
+var ulid1_8 = Ulid.New(unixTimestamp);
+Console.WriteLine($"1.8 New ULID from Unix Timestamp: {ulid1_8} (Time: {ulid1_8.Time})");
 
-// 1.5 Create a new ULID from byte array
+// 1.9 Create a new ULID from byte array
 var bytes = new byte[16];
 new Random().NextBytes(bytes); // Fill with some random bytes
-var ulid5 = Ulid.New(bytes);
-Console.WriteLine($"1.5 New ULID from byte array:     {ulid5}");
+var ulid1_9 = Ulid.New(bytes);
+Console.WriteLine($"1.9 New ULID from byte array:     {ulid1_9}");
 
-// 1.6 Create a new ULID from GUID
+// 1.10 Create a new ULID from GUID
 var guidToConvert = Guid.NewGuid();
-var ulid6 = Ulid.New(guidToConvert);
-Console.WriteLine($"1.6 New ULID from GUID:           {ulid6} (Original GUID: {guidToConvert})");
+var ulid1_10 = Ulid.New(guidToConvert);
+Console.WriteLine($"1.10 New ULID from GUID:          {ulid1_10} (Original GUID: {guidToConvert})");
 
 // --- 2. ULID Conversion Tests ---
 Console.WriteLine("\n--- ULID Conversion ---");
 
 // 2.1 ToByteArray()
-var ulid1ByteArray = ulid1.ToByteArray();
-Console.WriteLine($"2.1 ULID 1 ToByteArray(): {Convert.ToHexString(ulid1ByteArray)}");
+var ulid2_1ByteArray = ulid1_1.ToByteArray();
+Console.WriteLine($"2.1 ULID 1 ToByteArray(): {Convert.ToHexString(ulid2_1ByteArray)}");
 
 // 2.2 ToGuid()
-var ulid1Guid = ulid1.ToGuid();
-Console.WriteLine($"2.2 ULID 1 ToGuid():      {ulid1Guid}");
+var ulid2_2Guid = ulid1_1.ToGuid();
+Console.WriteLine($"2.2 ULID 1 ToGuid():      {ulid2_2Guid}");
 
 // 2.3 ToString()
-var ulid1String = ulid1.ToString();
-Console.WriteLine($"2.3 ULID 1 ToString():    {ulid1String}");
+var ulid2_3String = ulid1_1.ToString();
+Console.WriteLine($"2.3 ULID 1 ToString():    {ulid2_3String}");
 
 // 2.4 AsByteSpan()
-var ulid1ByteSpan = ulid1.AsByteSpan();
-Console.WriteLine($"2.4 ULID 1 AsByteSpan() (first 4 bytes): {Convert.ToHexString(ulid1ByteSpan[..4].ToArray())}");
-
+var ulid2_4ByteSpan = ulid1_1.AsByteSpan();
+Console.WriteLine($"2.4 ULID 1 AsByteSpan() (first 4 bytes): {Convert.ToHexString(ulid2_4ByteSpan[..4].ToArray())}");
 
 // --- 3. ULID Parsing Tests ---
 Console.WriteLine("\n--- ULID Parsing ---");
 
 // 3.1 Parse from string
-var parsedUlid1 = Ulid.Parse(ulid1String);
-Console.WriteLine($"3.1 Parsed ULID from string '{ulid1String}': {parsedUlid1}");
-Console.WriteLine($"    Equality check (ulid1 == parsedUlid1): {ulid1 == parsedUlid1}");
+var ulid3_1 = Ulid.Parse(ulid2_3String);
+Console.WriteLine($"3.1 Parsed ULID from string '{ulid2_3String}': {ulid3_1}");
+Console.WriteLine($"    Equality check (ulid1_1 == ulid3_1): {ulid1_1 == ulid3_1}");
 
 // 3.2 TryParse from string
-if (Ulid.TryParse("01ARZ3NDEKTSV4RRQ6S5KF8XRY", null, out var tryParsedUlid))
+if (Ulid.TryParse("01ARZ3NDEKTSV4RRQ6S5KF8XRY", null, out var ulid3_2))
 {
-	Console.WriteLine($"3.2 TryParse successful: {tryParsedUlid}");
+    Console.WriteLine($"3.2 TryParse successful: {ulid3_2}");
 }
 else
 {
-	Console.WriteLine("3.2 TryParse failed for valid ULID.");
+    throw new("3.2 ERROR: TryParse failed for valid ULID.");
 }
 
 // 3.3 TryParse with invalid string
-if (!Ulid.TryParse("INVALID_ULID_STRING", null, out var failedParseUlid))
+if (!Ulid.TryParse("INVALID_ULID_STRING", null, out var ulid3_3))
 {
-	Console.WriteLine("3.3 TryParse correctly failed for invalid ULID string.");
+    Console.WriteLine("3.3 TryParse correctly failed for invalid ULID string.");
 }
 else
 {
-	Console.WriteLine($"3.3 TryParse unexpectedly succeeded for invalid ULID string: {failedParseUlid}");
+	throw new($"3.3 ERROR: TryParse unexpectedly succeeded for invalid ULID string: {ulid3_3}");
 }
 
 // --- 4. ULID Validation Tests ---
 Console.WriteLine("\n--- ULID Validation ---");
 
 // 4.1 IsValid with valid string
-Console.WriteLine($"4.1 IsValid('{ulid1String}'): {Ulid.IsValid(ulid1String)}");
+Console.WriteLine($"4.1 IsValid('{ulid2_3String}'): {Ulid.IsValid(ulid2_3String)}");
 
 // 4.2 IsValid with invalid string
 Console.WriteLine($"4.2 IsValid('NOT_A_ULID'): {Ulid.IsValid("NOT_A_ULID")}");
 
 // 4.3 IsValid with byte array
-Console.WriteLine($"4.3 IsValid(byte[] of ulid1): {Ulid.IsValid(ulid1ByteArray)}");
-
+Console.WriteLine($"4.3 IsValid(byte[] of ulid1_1): {Ulid.IsValid(ulid2_1ByteArray)}");
 
 // --- 5. ULID Property Access Tests ---
 Console.WriteLine("\n--- ULID Property Access ---");
 
-Console.WriteLine($"5.1 ULID 1 Time component:    {ulid1.Time}");
-Console.WriteLine($"5.2 ULID 1 TimeBytes (first 4 bytes): {Convert.ToHexString(ulid1.TimeBytes[..4].ToArray())}");
-Console.WriteLine($"5.3 ULID 1 Random (first 4 bytes):    {Convert.ToHexString(ulid1.Random[..4].ToArray())}");
+Console.WriteLine($"5.1 ULID 1 Time component:    {ulid1_1.Time}");
+Console.WriteLine($"5.2 ULID 1 TimeBytes (first 4 bytes): {Convert.ToHexString(ulid1_1.TimeBytes[..4].ToArray())}");
+Console.WriteLine($"5.3 ULID 1 Random (first 4 bytes):    {Convert.ToHexString(ulid1_1.Random[..4].ToArray())}");
 Console.WriteLine($"5.4 Ulid.Empty:               {Ulid.Empty}");
-
 
 // --- 6. Comparison Operator Tests ---
 Console.WriteLine("\n--- Comparison Operators ---");
-var compareUlid1 = Ulid.New(specificTime);
-var compareUlid2 = Ulid.New(specificTime.AddMilliseconds(1));
-var compareUlid3 = Ulid.New(specificTime); // Same timestamp, potentially different random
+var ulid6_1 = Ulid.New(specificTime);
+var ulid6_2 = Ulid.New(specificTime.AddMilliseconds(1));
+var ulid6_3 = Ulid.New(specificTime); // Same timestamp, potentially different random
 
-Console.WriteLine($"Compare ULID 1: {compareUlid1}");
-Console.WriteLine($"Compare ULID 2: {compareUlid2}");
-Console.WriteLine($"Compare ULID 3: {compareUlid3}");
+Console.WriteLine($"Compare ULID 1: {ulid6_1}");
+Console.WriteLine($"Compare ULID 2: {ulid6_2}");
+Console.WriteLine($"Compare ULID 3: {ulid6_3}");
 
-Console.WriteLine($"6.1 compareUlid1 == compareUlid3: {compareUlid1 == compareUlid3}"); // Should be true if random part also matches, depends on generation
-Console.WriteLine($"6.2 compareUlid1 != compareUlid2: {compareUlid1 != compareUlid2}");
-Console.WriteLine($"6.3 compareUlid1 < compareUlid2:  {compareUlid1 < compareUlid2}");
-Console.WriteLine($"6.4 compareUlid1 <= compareUlid3: {compareUlid1 <= compareUlid3}");
-Console.WriteLine($"6.5 compareUlid2 > compareUlid1:  {compareUlid2 > compareUlid1}");
-Console.WriteLine($"6.6 compareUlid2 >= compareUlid3: {compareUlid2 >= compareUlid3}");
+Console.WriteLine($"6.1 ulid6_1 == ulid6_3: {ulid6_1 == ulid6_3}"); // Should be true if random part also matches, depends on generation
+Console.WriteLine($"6.2 ulid6_1 != ulid6_2: {ulid6_1 != ulid6_2}");
+Console.WriteLine($"6.3 ulid6_1 < ulid6_2:  {ulid6_1 < ulid6_2}");
+Console.WriteLine($"6.4 ulid6_1 <= ulid6_3: {ulid6_1 <= ulid6_3}");
+Console.WriteLine($"6.5 ulid6_2 > ulid6_1:  {ulid6_2 > ulid6_1}");
+Console.WriteLine($"6.6 ulid6_2 >= ulid6_3: {ulid6_2 >= ulid6_3}");
 
-Console.WriteLine($"6.7 CompareTo (ulid1 vs ulid2): {ulid1.CompareTo(ulid2)}"); // Should be negative if ulid1 is earlier
-Console.WriteLine($"6.8 Equals (ulid1 vs ulid1): {ulid1.Equals(ulid1)}");
-Console.WriteLine($"6.9 Equals (ulid1 vs ulid2): {ulid1.Equals(ulid2)}");
-Console.WriteLine($"6.10 GetHashCode (ulid1): {ulid1.GetHashCode()}");
+Console.WriteLine($"6.7 CompareTo (ulid1_1 vs ulid1_2): {ulid1_1.CompareTo(ulid1_2)}"); // Should be negative if ulid1_1 is earlier
+Console.WriteLine($"6.8 Equals (ulid1_1 vs ulid1_1): {ulid1_1.Equals(ulid1_1)}");
+Console.WriteLine($"6.9 Equals (ulid1_1 vs ulid1_2): {ulid1_1.Equals(ulid1_2)}");
+Console.WriteLine($"6.10 GetHashCode (ulid1_1): {ulid1_1.GetHashCode()}");
 
 // --- 7. System.Text.Json Integration Test ---
 Console.WriteLine("\n--- System.Text.Json Integration (Requires UlidJsonConverter if not using default settings) ---");
 
 // Create an instance of MyClassWithUlid instead of an anonymous type
-var myObject = new MyClassWithUlid { Id = Ulid.New(), Name = "Test Item" };
+var ulid7_1Object = new MyClassWithUlid { Id = Ulid.New(), Name = "Test Item" };
 
 // Use the generated TypeInfo from UlidJsonContext for MyClassWithUlid
-var jsonString = JsonSerializer.Serialize(myObject, UlidJsonContext.Default.MyClassWithUlid);
+var jsonString = JsonSerializer.Serialize(ulid7_1Object, UlidJsonContext.Default.MyClassWithUlid);
 Console.WriteLine($"7.1 Serialized object with ULID: {jsonString}");
 
 // Deserialize the object using the generated TypeInfo for MyClassWithUlid
-var deserializedObject = JsonSerializer.Deserialize(jsonString, UlidJsonContext.Default.MyClassWithUlid);
-Console.WriteLine($"7.2 Deserialized object ULID: {deserializedObject?.Id}, Name: {deserializedObject?.Name}");
-Console.WriteLine($"    Equality check (Original Id == Deserialized Id): {myObject.Id == deserializedObject?.Id}");
+var ulid7_2Object = JsonSerializer.Deserialize(jsonString, UlidJsonContext.Default.MyClassWithUlid);
+Console.WriteLine($"7.2 Deserialized object ULID: {ulid7_2Object?.Id}, Name: {ulid7_2Object?.Name}");
+Console.WriteLine($"    Equality check (Original Id == Deserialized Id): {ulid7_1Object.Id == ulid7_2Object?.Id}");
 
 Console.WriteLine("\n--------------------------------------------------");
 Console.WriteLine("ByteAether.Ulid AOT Compatibility Test Completed.");
 
 internal class MyClassWithUlid
 {
-	public Ulid Id { get; set; }
-	public string? Name { get; set; }
+    public Ulid Id { get; set; }
+    public string? Name { get; set; }
 }
 
 [JsonSerializable(typeof(Ulid))]

--- a/src/ByteAether.Ulid.Tests/ByteAether.Ulid.Tests.csproj
+++ b/src/ByteAether.Ulid.Tests/ByteAether.Ulid.Tests.csproj
@@ -28,6 +28,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'"/>
+    <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
 
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
       <PrivateAssets>all</PrivateAssets>

--- a/src/ByteAether.Ulid.Tests/Ulid.Comparable.Tests.cs
+++ b/src/ByteAether.Ulid.Tests/Ulid.Comparable.Tests.cs
@@ -24,8 +24,8 @@ public class UlidComparableTests
 	public void CompareTo_CompareToNewerUlid_ShouldReturnNegative()
 	{
 		// Arrange
-		var ulid1 = Ulid.New(true);
-		var ulid2 = Ulid.New(true);
+		var ulid1 = Ulid.New(Ulid.Monotonicity.MonotonicIncrement);
+		var ulid2 = Ulid.New(Ulid.Monotonicity.MonotonicIncrement);
 
 		// Act
 		var comparisonResult = ulid1.CompareTo(ulid2);
@@ -42,8 +42,8 @@ public class UlidComparableTests
 	public void CompareTo_CompareToOlderUlid_ShouldReturnPositive()
 	{
 		// Arrange
-		var ulid1 = Ulid.New(true);
-		var ulid2 = Ulid.New(true);
+		var ulid1 = Ulid.New(Ulid.Monotonicity.MonotonicIncrement);
+		var ulid2 = Ulid.New(Ulid.Monotonicity.MonotonicIncrement);
 
 		// Act
 		var comparisonResult = ulid2.CompareTo(ulid1);

--- a/src/ByteAether.Ulid.Tests/Ulid.New.Tests.cs
+++ b/src/ByteAether.Ulid.Tests/Ulid.New.Tests.cs
@@ -18,30 +18,28 @@ public class UlidNewTests
 	}
 
 	[Theory]
-	[InlineData(true)]
-	[InlineData(false)]
-	public void New_ShouldGenerateUniqueUlids(bool isMonotonic)
+	[CombinatorialData]
+	public void New_ShouldGenerateUniqueUlids(Ulid.Monotonicity monotonicity)
 	{
 		// Act
-		var ulid1 = Ulid.New(isMonotonic);
-		var ulid2 = Ulid.New(isMonotonic);
+		var ulid1 = Ulid.New(monotonicity);
+		var ulid2 = Ulid.New(monotonicity);
 
 		// Assert
 		Assert.NotEqual(ulid1, ulid2);
 	}
 
 	[Theory]
-	[InlineData(true)]
-	[InlineData(false)]
-	public void New_WithDateTime_ShouldGenerateUniqueUlids(bool isMonotonic)
+	[CombinatorialData]
+	public void New_WithDateTime_ShouldGenerateUniqueUlids(Ulid.Monotonicity monotonicity)
 	{
 		// Arrange
 		var dateTimeOffset = DateTimeOffset.UtcNow;
 		var timestamp = dateTimeOffset.ToUnixTimeMilliseconds();
 
 		// Act
-		var ulid1 = Ulid.New(dateTimeOffset, isMonotonic);
-		var ulid2 = Ulid.New(dateTimeOffset, isMonotonic);
+		var ulid1 = Ulid.New(dateTimeOffset, monotonicity);
+		var ulid2 = Ulid.New(dateTimeOffset, monotonicity);
 
 		// Assert
 		Assert.NotEqual(ulid1, ulid2);
@@ -50,7 +48,7 @@ public class UlidNewTests
 		Assert.True(timestamp <= ulid1.Time.ToUnixTimeMilliseconds());
 		Assert.True(timestamp <= ulid2.Time.ToUnixTimeMilliseconds());
 
-		if (isMonotonic)
+		if (monotonicity != Ulid.Monotonicity.NonMonotonic)
 		{
 			Assert.True(MemoryExtensions.SequenceCompareTo(ulid1.AsByteSpan(), ulid2.AsByteSpan()) < 0);
 			Assert.True(ulid1 < ulid2);
@@ -58,17 +56,16 @@ public class UlidNewTests
 	}
 
 	[Theory]
-	[InlineData(true)]
-	[InlineData(false)]
-	public void New_WithTimestamp_ShouldGenerateUniqueUlids(bool isMonotonic)
+	[CombinatorialData]
+	public void New_WithTimestamp_ShouldGenerateUniqueUlids(Ulid.Monotonicity monotonicity)
 	{
 		// Arrange
 		var dateTimeOffset = DateTimeOffset.UtcNow;
 		var timestamp = dateTimeOffset.ToUnixTimeMilliseconds();
 
 		// Act
-		var ulid1 = Ulid.New(timestamp, isMonotonic);
-		var ulid2 = Ulid.New(timestamp, isMonotonic);
+		var ulid1 = Ulid.New(timestamp, monotonicity);
+		var ulid2 = Ulid.New(timestamp, monotonicity);
 
 		// Assert
 		Assert.NotEqual(ulid1, ulid2);
@@ -77,7 +74,7 @@ public class UlidNewTests
 		Assert.True(timestamp <= ulid1.Time.ToUnixTimeMilliseconds());
 		Assert.True(timestamp <= ulid2.Time.ToUnixTimeMilliseconds());
 
-		if (isMonotonic)
+		if (monotonicity != Ulid.Monotonicity.NonMonotonic)
 		{
 			Assert.True(MemoryExtensions.SequenceCompareTo(ulid1.AsByteSpan(), ulid2.AsByteSpan()) < 0);
 			Assert.True(ulid1 < ulid2);
@@ -133,20 +130,17 @@ public class UlidNewTests
 	}
 
 	[Theory]
-	[InlineData(false)]
-	[InlineData(true)]
-	[InlineData(null, true)]
-	[InlineData(null, false)]
-	public void New_WithTimestampAndMonotonicSet_ShouldGenerateUniqueUlids(bool? isMonotonic, bool defaultIsMonotonic = true)
+	[CombinatorialData]
+	public void New_WithTimestampAndMonotonicSet_ShouldGenerateUniqueUlids(Ulid.Monotonicity? monotonicity, Ulid.Monotonicity defaultMonotonicity)
 	{
 		// Arrange
-		Ulid.DefaultIsMonotonic = defaultIsMonotonic;
+		Ulid.DefaultMonotonicity = defaultMonotonicity;
 		var dateTimeOffset = DateTimeOffset.UtcNow;
 		var timestamp = dateTimeOffset.ToUnixTimeMilliseconds();
 
 		// Act
-		var ulid1 = Ulid.New(timestamp, isMonotonic);
-		var ulid2 = Ulid.New(timestamp, isMonotonic);
+		var ulid1 = Ulid.New(timestamp, monotonicity);
+		var ulid2 = Ulid.New(timestamp, monotonicity);
 
 		// Assert
 		Assert.NotEqual(ulid1, ulid2);
@@ -155,7 +149,7 @@ public class UlidNewTests
 		Assert.True(timestamp <= ulid1.Time.ToUnixTimeMilliseconds());
 		Assert.True(timestamp <= ulid2.Time.ToUnixTimeMilliseconds());
 
-		if (isMonotonic ?? defaultIsMonotonic)
+		if ((monotonicity ?? defaultMonotonicity) != Ulid.Monotonicity.NonMonotonic)
 		{
 			Assert.True(MemoryExtensions.SequenceCompareTo(ulid1.AsByteSpan(), ulid2.AsByteSpan()) < 0);
 			Assert.True(ulid1 < ulid2);

--- a/src/ByteAether.Ulid/Ulid.New.cs
+++ b/src/ByteAether.Ulid/Ulid.New.cs
@@ -95,11 +95,16 @@ public readonly partial struct Ulid
 
 	private static readonly byte[] _lastUlid = new byte[_ulidSize];
 	private static readonly RandomNumberGenerator _rng = RandomNumberGenerator.Create();
+#if NET6_0_OR_GREATER
+	private static Random _rngSimple => System.Random.Shared;
+#else
+	private static readonly Random _rngSimple = new();
+#endif
 
 #if NET9_0_OR_GREATER
 	private static readonly Lock _lock = new();
 #else
-    private static readonly object _lock = new();
+	private static readonly object _lock = new();
 #endif
 
 	/// <summary>
@@ -213,6 +218,7 @@ public readonly partial struct Ulid
 #if NET5_0_OR_GREATER
 	[SkipLocalsInit]
 #endif
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static void FillTime(Span<byte> bytes, long timestamp)
 	{
 		unsafe
@@ -248,6 +254,7 @@ public readonly partial struct Ulid
 #if NET5_0_OR_GREATER
 	[SkipLocalsInit]
 #endif
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static void FillRandom(Span<byte> bytes, Monotonicity monotonicity)
 	{
 		if (monotonicity == Monotonicity.NonMonotonic)
@@ -263,17 +270,16 @@ public readonly partial struct Ulid
 			// If the timestamp is the same or lesser than the last one, increment the last ULID by one
 			if (bytes[.._ulidSizeTime].SequenceCompareTo(lastUlidSpan[.._ulidSizeTime]) <= 0)
 			{
-				if (monotonicity == Monotonicity.MonotonicIncrement)
+				// We can use the last bytes of incomplete ULID for the increment parameter
+				var randomByteCount = (int)monotonicity;
+				var tempSpan = bytes.Slice(_ulidSize - randomByteCount, randomByteCount);
+
+				if (randomByteCount > 0)
 				{
-					IncrementByteSpan(lastUlidSpan, ReadOnlySpan<byte>.Empty);
+					_rngSimple.NextBytes(tempSpan);
 				}
-				else
-				{
-					var randomByteCount = (int)monotonicity;
-					// We can use the last bytes of incomplete ULID for the increment parameter
-					_rng.GetBytes(bytes[..^randomByteCount]);
-					IncrementByteSpan(lastUlidSpan, bytes[..^randomByteCount]);
-				}
+
+				IncrementByteSpan(lastUlidSpan, tempSpan);
 			}
 			// Otherwise, generate a new ULID
 			else
@@ -289,7 +295,6 @@ public readonly partial struct Ulid
 #if NET5_0_OR_GREATER
 	[SkipLocalsInit]
 #endif
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static void IncrementByteSpan(Span<byte> targetSpan, ReadOnlySpan<byte> sourceSpan)
 	{
 		ushort carry = 1; // max sum 255+255+1 = 511; guarantee at least +1

--- a/src/ByteAether.Ulid/Ulid.cs
+++ b/src/ByteAether.Ulid/Ulid.cs
@@ -12,7 +12,7 @@ namespace ByteAether.Ulid;
 /// Represents a Universally Unique Lexicographically Sortable Identifier (ULID).
 /// </summary>
 /// <remarks>
-/// A ULID is a 128-bit identifier that is sortable by time and consists of a timestamp and random components. 
+/// A ULID is a 128-bit identifier that is sortable by time and consists of a timestamp and random components.
 /// For more information, visit <see href="https://github.com/ByteAether/Ulid">the GitHub repository</see>.
 /// </remarks>
 #if NETCOREAPP
@@ -90,10 +90,10 @@ public readonly partial struct Ulid
 	/// Gets the timestamp component of the ULID as a <see cref="DateTimeOffset"/>.
 	/// </summary>
 	/// <remarks>
-	/// The timestamp component represents the number of milliseconds since the Unix epoch 
-	/// (1970-01-01T00:00:00Z). It is stored in the first 6 bytes of the ULID and ensures 
+	/// The timestamp component represents the number of milliseconds since the Unix epoch
+	/// (1970-01-01T00:00:00Z). It is stored in the first 6 bytes of the ULID and ensures
 	/// lexicographical sorting by time.
-	/// 
+	///
 	/// The timestamp is extracted in a way that is compatible with both little-endian and big-endian systems.
 	/// </remarks>
 	/// <returns>

--- a/src/ByteAether.Ulid/netstandard20/RandomNumberGeneratorExtensions.cs
+++ b/src/ByteAether.Ulid/netstandard20/RandomNumberGeneratorExtensions.cs
@@ -1,0 +1,17 @@
+#if NETSTANDARD2_0
+using System.Buffers;
+using System.Security.Cryptography;
+
+namespace ByteAether.Ulid;
+
+internal static class RandomNumberGeneratorExtensions
+{
+	// In NetStandard 2.0, RandomNumberGenerator.GetBytes() does not support Span<byte> overloads.
+	public static void GetBytes(this RandomNumberGenerator rng, Span<byte> buffer)
+	{
+		var rndInc = ArrayPool<byte>.Shared.Rent(buffer.Length);
+		rng.GetBytes(rndInc, 0, buffer.Length);
+		new ReadOnlySpan<byte>(rndInc, 0, buffer.Length).CopyTo(buffer);
+	}
+}
+#endif

--- a/src/ByteAether.Ulid/netstandard20/RandomNumberGeneratorExtensions.cs
+++ b/src/ByteAether.Ulid/netstandard20/RandomNumberGeneratorExtensions.cs
@@ -1,5 +1,6 @@
 #if NETSTANDARD2_0
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 
 namespace ByteAether.Ulid;
@@ -7,10 +8,20 @@ namespace ByteAether.Ulid;
 internal static class RandomNumberGeneratorExtensions
 {
 	// In NetStandard 2.0, RandomNumberGenerator.GetBytes() does not support Span<byte> overloads.
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static void GetBytes(this RandomNumberGenerator rng, Span<byte> buffer)
 	{
 		var rndInc = ArrayPool<byte>.Shared.Rent(buffer.Length);
 		rng.GetBytes(rndInc, 0, buffer.Length);
+		new ReadOnlySpan<byte>(rndInc, 0, buffer.Length).CopyTo(buffer);
+	}
+
+	// In NetStandard 2.0, Random.NextBytes() does not support Span<byte> overloads.
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static void NextBytes(this Random rng, Span<byte> buffer)
+	{
+		var rndInc = ArrayPool<byte>.Shared.Rent(buffer.Length);
+		rng.NextBytes(rndInc);
 		new ReadOnlySpan<byte>(rndInc, 0, buffer.Length).CopyTo(buffer);
 	}
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

Refactored ULID creation API to support customizable monotonicity optons. Replaced `isMonotonic` with an extensible `Monotonicity` enum. Enhanced test and example coverage to include various monotonic modes. Improved `RandomNumberGenerator` handling for netstandard2.0.

## Description
<!-- Provide a detailed description of your changes and explain why they are needed. -->

Implements `Ulid.Monotonicity` enum with values of `NonMonotonic`, `MonotonicIncrement`, `MonotonicRandom1Byte`, `MonotonicRandom2Byte`, `MonotonicRandom3Byte`, `MonotonicRandom4Byte` and a property of `Ulid.DefaultMonotonicity` replacing `Ulid.DefaultIsMonotonic`. Added options allow monotonic increment to be a random value in size of 1-4 bytes.

## Related Issues
<!-- List any related issues by number (e.g., "Fixes #123", "Closes #456"). -->

- Fixes #13

## Type of Change
<!-- Check all that apply and provide more details if needed. Put an `x` in only one box that applies best: -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
<!-- Ensure the following tasks are completed before submission. -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The PR is submitted to the correct branch (`main`).
- [ ] My code follows the project's coding style. (`.editorconfig`)
- [ ] I have commented my code, particularly in hard-to-understand areas and public interfaces.
- [ ] I have added or updated tests for the changes I made.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation where applicable.

## Additional Notes
<!-- Add any other relevant context, considerations, or important details. -->
This is a draft implementation.
