### PR TITLE
Fixed HW accelerated SSSE3 shuffle capability detection for NET 6.0 and older

### DIFF
--- a/src/ByteAether.Ulid/Ulid.Guid.cs
+++ b/src/ByteAether.Ulid/Ulid.Guid.cs
@@ -144,7 +144,7 @@ public readonly partial struct Ulid
 #if NET7_0_OR_GREATER
 		Vector128.IsHardwareAccelerated;
 #else
-		Sse3.IsSupported;
+		Ssse3.IsSupported;
 #endif
 
 	private static readonly Vector128<byte> _shuffleMask


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Provide a detailed description of your changes and explain why they are needed. -->
Corrected the hardware acceleration check to use `Ssse3.IsSupported` instead of `Sse3.IsSupported`. The byte-level shuffling instruction (`pshufb`) was introduced in the **Supplemental** SSE3 (SSSE3) instruction set, and relying on the standard SSE3 flag would cause a `NotImplementedException` on .NET 6.0 and older when running on hardware that lacks the supplemental extensions.

## Type of Change
<!-- Check all that apply and provide more details if needed. Put an `x` in only one box that applies best: -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
<!-- Ensure the following tasks are completed before submission. -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The PR is submitted to the correct branch (`main`).
- [x] My code follows the project's coding style. (`.editorconfig`)
- [x] I have commented my code, particularly in hard-to-understand areas and public interfaces.
- [x] I have added or updated tests for the changes I made.
- [x] All new and existing tests passed.
- [x] I have updated the documentation where applicable.
